### PR TITLE
modified AddEdit Identity Page to respect state better

### DIFF
--- a/src/layoutes/Dshboard.tsx
+++ b/src/layoutes/Dshboard.tsx
@@ -1,4 +1,4 @@
-import AddIdentityPage from "@/pages/AddIdentityPage";
+import AddOrEditIdentityPage from "@/pages/AddOrEditIdentityPage";
 import DWebConnect from "@/pages/DwebConnect";
 import IdentitiesListPage from "@/pages/IdentitiesListPage";
 import IdentityDetailsPage from "@/pages/IdentityDetailsPage";
@@ -55,8 +55,8 @@ const Dashboard:React.FC = () => {
           <Route index element={<IdentitiesListPage />} />
           <Route path="/search" element={<SearchIdentitiesPage />} />
           <Route path= "/search/:didUri" element={<SearchIdentitiesPage />} />
-          <Route path="/identity/edit/:didUri" element={<AddIdentityPage edit />} />
-          <Route path="/identities/create" element={<AddIdentityPage />} />
+          <Route path="/identity/edit/:didUri" element={<AddOrEditIdentityPage edit />} />
+          <Route path="/identities/create" element={<AddOrEditIdentityPage />} />
           <Route path="/identities/import" element={<div>Coming Soon</div>} />
           <Route path="/identity/:didUri" element={<IdentityDetailsPage />} />
           <Route path="/dweb-connect" element={<DWebConnect />} />

--- a/src/pages/AddOrEditIdentityPage.tsx
+++ b/src/pages/AddOrEditIdentityPage.tsx
@@ -15,16 +15,16 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { Identity } from '@/lib/types';
 import { PageContainer } from '@toolpad/core';
 
-const AddIdentityPage: React.FC<{ edit?: boolean }> = ({ edit = false }) => {
+const AddOrEditIdentityPage: React.FC<{ edit?: boolean }> = ({ edit = false }) => {
   const { didUri } = useParams();
   const navigate = useNavigate();
-  const { createIdentity, updateIdentity, selectedIdentity, selectIdentity, identities, dwnEndpoints } = useIdentities();
+  const { createIdentity, updateIdentity, selectedIdentity, selectIdentity, dwnEndpoints } = useIdentities();
   const [loadedIdentity, setLoadedIdentity] = useState(false);
   const [loading, setLoading] = useState(false);
   const [avatarPreview, setAvatarPreview] = useState<string | null>(null);
   const [bannerPreview, setBannerPreview] = useState<string | null>(null);
 
-  const [formData, setFormData] = useState({
+  const defaultForm = {
     persona: '',
     displayName: '',
     tagline: '',
@@ -32,14 +32,29 @@ const AddIdentityPage: React.FC<{ edit?: boolean }> = ({ edit = false }) => {
     dwnEndpoints: ['https://dwn.tbddev.org/latest'],
     avatar: null as File | Blob | null,
     banner: null as File | Blob | null,
-  });
+  }
+
+  const [formData, setFormData] = useState(defaultForm);
 
   const isEdit = edit && selectedIdentity;
 
-  useEffect(() => {
+  const resetForm = () => {
+    setFormData(defaultForm);
+    setAvatarPreview(null);
+    setBannerPreview(null);
+  }
 
+  useEffect(() => {
+    if (didUri && selectedIdentity?.didUri !== didUri) {
+      selectIdentity(didUri);
+    }
+  }, [ didUri, selectedIdentity ]);
+
+  useEffect(() => {
     const loadIdentityForm = async () => {
-      if (!selectedIdentity) return;
+      if (!selectedIdentity) {
+        return;
+      };
 
       setFormData({
         persona: selectedIdentity.persona,
@@ -57,15 +72,14 @@ const AddIdentityPage: React.FC<{ edit?: boolean }> = ({ edit = false }) => {
       setLoadedIdentity(true);
     }
 
-    if (isEdit && !loadedIdentity) {
+    if (isEdit && selectedIdentity?.didUri === didUri && !loadedIdentity) {
       loadIdentityForm();
+    } else if (!isEdit && selectedIdentity) {
+      selectIdentity(undefined);
+      resetForm();
     }
 
-    if (!selectedIdentity) {
-      selectIdentity(didUri);
-    }
-
-  }, [ isEdit, selectedIdentity, didUri, identities, dwnEndpoints, loadedIdentity, selectIdentity ]);
+  }, [ isEdit, selectedIdentity, loadedIdentity, didUri ]);
 
 
   const submitDisabled = useMemo(() => {
@@ -332,4 +346,4 @@ const AddIdentityPage: React.FC<{ edit?: boolean }> = ({ edit = false }) => {
   );
 };
 
-export default AddIdentityPage;
+export default AddOrEditIdentityPage;


### PR DESCRIPTION
Renamed page to `AddOrEditIdentityPage` to better reflect what it does.

Modified the effect hooks to respect reloading formData and selectedIdentity when rendering the page. That way when switching from edit to create or between edited users the form is properly reset.